### PR TITLE
More idiomatic interface for `Args`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, fmt::Display};
 
 /// A wrapper around arguments being passed to `CommandPattern`. It is used to determine which
 /// source of arguments to use.
@@ -7,17 +7,17 @@ pub enum Args {
     CommandLineArgs,
 
     /// Tells the `CommandPattern` to use a custom user-defined `Vec` of arguments that implement
-    /// `ToString` trait. It is usually used for debugging or parsing purposes.
+    /// `Display` trait. It is usually used for debugging or parsing purposes.
     ///
     /// ### Example
     /// ```rust
     /// Args::Vec(vec!["new", "exe", "big_cat"]),
     /// ```
-    Vec(Vec<&'static dyn ToString>),
+    Vec(Vec<&'static dyn Display>),
 }
 
 impl Args {
-    pub fn as_vec(&self) -> Vec<String> {
+    pub fn to_vec(&self) -> Vec<String> {
         match self {
             Self::CommandLineArgs => env::args().collect(),
             Self::Vec(vec) => vec.iter().map(|arg| arg.to_string()).collect(),

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -61,7 +61,7 @@ impl<'a> Command<'a> {
     /// )
     /// ```
     pub fn from_args(args: Args, command_patterns: &[CommandPattern<'a>]) -> Result<Self, String> {
-        let args = args.as_vec();
+        let args = args.to_vec();
         let mut args = args.iter();
         _ = args.next();
 


### PR DESCRIPTION
- `dyn Display`, because `ToString` is generally meant only as an extension trait
- `to_vec`, because `as_` methods should return references or copied (not cloned/allocated) data

note that these are breaking changes